### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ Add the following to your list of dependencies in `pom.xml`
 ```
 <dependency>
     <groupId>com.sitture</groupId>
-    <artifactId>cucumber-jvm-extentsreport</artifactId>
-    <version>3.0.0</version>
+    <artifactId>cucumber-jvm-extentreport</artifactId>
+    <version>3.0.7</version>
 </dependency>
 ```
 
 Add the following if you're using gradle to your `build.gradle` file.
 
 ```
-compile 'com.sitture:cucumber-jvm-extentreport:3.0.0'
+compile 'com.sitture:cucumber-jvm-extentreport:3.0.7'
 ```
 
 ## Setup - Cucumber  Runner


### PR DESCRIPTION
It took me a bit too long to figure out the 1 letter typo that caused maven to not be able to resolve this artifact.

Also updated the version numbers to the latest version.